### PR TITLE
[BUG-FIX] fixed unintented change to relu from relu6

### DIFF
--- a/dissect/dissect_frac.py
+++ b/dissect/dissect_frac.py
@@ -43,6 +43,13 @@ def run_dissect_frac(config):
     n_features = X_sim_np.shape[1]
     n_celltypes = len(celltypes)
 
+    # Resolve the activation ONCE, before the ensemble loop, so the
+    # string sentinel isn't destroyed after the first iteration.
+    if config["deconv_params"]["network_params"]["hidden_activation"] == "relu6":
+        config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu6
+    else:
+        config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu
+
     j = 0
     for seed in range(len(config["deconv_params"]["models"])):
         print("Starting training model {}".format(j))
@@ -60,10 +67,6 @@ def run_dissect_frac(config):
         )
         dataset_iter = iter(dataset)
 
-        if config["deconv_params"]["network_params"]["hidden_activation"] == "relu6":
-            config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu6
-        else:
-            config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu
         model = network(
             config["deconv_params"]["network_params"], n_celltypes, n_features, training=True
         )


### PR DESCRIPTION
Hi,

I believe I found a mistake done in the code that I corrected. First let me describe the problem that I found in the
**dissect_frac.py** script.


The mistake happens inside the for loop.
Old code:
```
j = 0
for seed in range(len(config["deconv_params"]["models"])):
    print("Starting training model {}".format(j))

    np.random.seed(seed)
    tf.random.set_seed(seed)

    if config["deconv_params"]["network_params"]["hidden_activation"] == "relu6":
        config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu6
    else:
        config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu

    model = network(
        config["deconv_params"]["network_params"],
        n_celltypes,
        n_features,
        training=True,
    )
```
The code checks whether the configured activation is the text value "relu6" inside the loop.

During the first ensemble iteration, that check succeeds. The code then replaces the text "relu6" with the TensorFlow function tf.nn.relu6.

I believe that during the second iteration, the value is no longer the text "relu6"; it is already a function. The same text comparison therefore fails, and the code enters the else branch, replacing ReLU6 with ordinary ReLU.

In other words, the old behavior was effectively:

```
model 1 -> ReLU6
model 2 -> ReLU
model 3 -> ReLU
model 4 -> ReLU
model 5 -> ReLU
```

The intended behavior (at least according to what you described in the paper) is:

```
model 1 -> ReLU6
model 2 -> ReLU6
model 3 -> ReLU6
model 4 -> ReLU6
model 5 -> ReLU6
```
The change I added was to place the if statement outside the for loop.

```
# Resolve the activation once before the ensemble loop.
if config["deconv_params"]["network_params"]["hidden_activation"] == "relu6":
    config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu6
else:
    config["deconv_params"]["network_params"]["hidden_activation"] = tf.nn.relu

j = 0
for seed in range(len(config["deconv_params"]["models"])):
    print("Starting training model {}".format(j))

    np.random.seed(seed)
    tf.random.set_seed(seed)

    model = network(
        config["deconv_params"]["network_params"],
        n_celltypes,
        n_features,
        training=True,
    )
```

It should now work as intented now.

Best regards,
Sergej Ruff

